### PR TITLE
feat(resources): import state for 'bigquery_warehouse'

### DIFF
--- a/docs/index.md
+++ b/docs/index.md
@@ -42,5 +42,5 @@ provider "monte_carlo" {
 
 Required:
 
-- `id` (String, Sensitive) Monte Carlo _Account service key_ **ID**.
-- `token` (String, Sensitive) Monte Carlo _Account service key_ **token**.
+- `id` (String, Sensitive) Monte Carlo **Account service key** _ID_.
+- `token` (String, Sensitive) Monte Carlo **Account service key** _token_.

--- a/main.go
+++ b/main.go
@@ -19,9 +19,6 @@ import (
 // Run the docs generation tool, check its repository for more information on how it works and how docs can be customized.
 //go:generate go run github.com/hashicorp/terraform-plugin-docs/cmd/tfplugindocs@v0.16.0
 
-// Run the docs generation tool, check its repository for more information on how it works and how docs can be customized.
-//go:generate go run github.com/hashicorp/go-changelog/cmd/changelog-pr-body-check@latest
-
 var (
 	// these will be set by the goreleaser configuration
 	// to appropriate values for the compiled binary.

--- a/monte_carlo/resources/bigquery_warehouse.go
+++ b/monte_carlo/resources/bigquery_warehouse.go
@@ -5,6 +5,7 @@ import (
 	b64 "encoding/base64"
 	"encoding/json"
 	"fmt"
+	"strings"
 
 	"github.com/kiwicom/terraform-provider-montecarlo/monte_carlo/client"
 	"github.com/kiwicom/terraform-provider-montecarlo/monte_carlo/common"
@@ -267,7 +268,17 @@ func (r *BigQueryWarehouseResource) Delete(ctx context.Context, req resource.Del
 }
 
 func (r *BigQueryWarehouseResource) ImportState(ctx context.Context, req resource.ImportStateRequest, resp *resource.ImportStateResponse) {
-	resource.ImportStatePassthroughID(ctx, path.Root("id"), req, resp)
+	idsImported := strings.Split(req.ID, ",")
+	if len(idsImported) != 2 || idsImported[0] == "" || idsImported[1] == "" {
+		resp.Diagnostics.AddError(
+			"Unexpected Import Identifier",
+			fmt.Sprintf("Expected import identifier with format: <uuid>,<connection_uuid>. Got: %q", req.ID),
+		)
+		return
+	}
+
+	resp.Diagnostics.Append(resp.State.SetAttribute(ctx, path.Root("uuid"), idsImported[0])...)
+	resp.Diagnostics.Append(resp.State.SetAttribute(ctx, path.Root("connection_uuid"), idsImported[1])...)
 }
 
 func (r *BigQueryWarehouseResource) addConnection(ctx context.Context, data BigQueryWarehouseResourceModel) (*BigQueryWarehouseResourceModel, diag.Diagnostics) {


### PR DESCRIPTION
**Terraform** resources might be configured to import existing state of their "real-world" counterpart.  
For this functionality to work it is necessary that **Terraform** resource implements function `ImportState`.  

This function is called during the `terraform import` command and uses single argument to attach **Terraform** resource to an existing external state. If multiple arguments are required for this action then proper workarounds must be included.  

You can find more in the **Import State** [documentation](https://developer.hashicorp.com/terraform/plugin/framework/resources/import) from **Terraform**.