### PR TITLE
chore(ci|cd): prepare for v0.1.0 release

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,4 +1,24 @@
 
+
+<a name="v0.1.0"></a>
+## [v0.1.0](https://github.com/kiwicom/terraform-provider-montecarlo/compare/v0.0.1...v0.1.0)
+
+> 2023-09-30
+
+### Bug Fixes
+
+* **release|registry:** provider naming and docs for registry ([#8](https://github.com/kiwicom/terraform-provider-montecarlo/issues/8))
+* **repo|reports:** broken links and unnecessary newlines ([#13](https://github.com/kiwicom/terraform-provider-montecarlo/issues/13))
+
+### Features
+
+* **release|registry:** manifest for Terraform registry ([#9](https://github.com/kiwicom/terraform-provider-montecarlo/issues/9))
+* **repo:** github changelog and release notes ([#10](https://github.com/kiwicom/terraform-provider-montecarlo/issues/10))
+* **repo|docs:** finished basic community standard documents ([#11](https://github.com/kiwicom/terraform-provider-montecarlo/issues/11))
+* **repo|reports:** migrate to beta issue forms ([#12](https://github.com/kiwicom/terraform-provider-montecarlo/issues/12))
+* **resources:** import state for 'bigquery_warehouse' ([#14](https://github.com/kiwicom/terraform-provider-montecarlo/issues/14))
+
+
 <a name="v0.0.1"></a>
 ## v0.0.1
 

--- a/docs/resources/bigquery_warehouse.md
+++ b/docs/resources/bigquery_warehouse.md
@@ -26,7 +26,7 @@ resource "montecarlo_bigquery_warehouse" "example" {
 
 ### Required
 
-- `data_collector_uuid` (String) Unique identifier of data collector this warehouse will be attached to. Its not possible to change data collectors of already created warehouse, therefore if Terraform detects change in this attribute it will plan recreation (which might not be successfull due to deletion protection flag). Since this property is immutable in Monte Carlo warehouses it can be only changed in the configuration
+- `data_collector_uuid` (String) Unique identifier of data collector this warehouse will be attached to. Its not possible to change data collectors of already created warehouses, therefore if Terraform detects change in this attribute it will plan recreation (which might not be successfull due to deletion protection flag). Since this property is immutable in Monte Carlo warehouses it can only be changed in the configuration
 - `name` (String) The name of the BigQuery warehouse as it will be presented in Monte Carlo.
 - `service_account_key` (String, Sensitive) Service account key used by the warehouse connection for authentication and authorization against BigQuery. The very same service account is used to grant required permissions to Monte Carlo BigQuery warehouse for the data access. For more information follow Monte Carlo documentation: https://docs.getmontecarlo.com/docs/bigquery
 


### PR DESCRIPTION
<a name="v0.1.0"></a>
## [v0.1.0](https://github.com/kiwicom/terraform-provider-montecarlo/compare/v0.0.1...v0.1.0)

> 2023-09-30

### Bug Fixes

* **release|registry:** provider naming and docs for registry ([#8](https://github.com/kiwicom/terraform-provider-montecarlo/issues/8))
* **repo|reports:** broken links and unnecessary newlines ([#13](https://github.com/kiwicom/terraform-provider-montecarlo/issues/13))

### Features

* **release|registry:** manifest for Terraform registry ([#9](https://github.com/kiwicom/terraform-provider-montecarlo/issues/9))
* **repo:** github changelog and release notes ([#10](https://github.com/kiwicom/terraform-provider-montecarlo/issues/10))
* **repo|docs:** finished basic community standard documents ([#11](https://github.com/kiwicom/terraform-provider-montecarlo/issues/11))
* **repo|reports:** migrate to beta issue forms ([#12](https://github.com/kiwicom/terraform-provider-montecarlo/issues/12))
* **resources:** import state for 'bigquery_warehouse' ([#14](https://github.com/kiwicom/terraform-provider-montecarlo/issues/14))