### PR TITLE
chore(release): ignore intermediate file 'release-notes.md'

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -35,3 +35,4 @@ website/vendor
 
 # goreleaser
 dist/
+release-notes.md


### PR DESCRIPTION
GitHub actions workflow was configured to create **intermediate** `release-notes.md` file containing changelog for current release.  This configuration caused `goreleaser` tool to fail since it was thinking that git happened to be in the dirty state (new files).  
[https://github.com/kiwicom/terraform-provider-montecarlo/actions/runs/6361155384](https://github.com/kiwicom/terraform-provider-montecarlo/actions/runs/6361155384)

`.gitignore` was fixed to include `release-notes.md` file ignore rule as well.