### PR TITLE
chore(release): goreleaser --release-notes invalid input

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -40,7 +40,7 @@ jobs:
         with:
           distribution: goreleaser
           version: latest
-          args: release --clean --release-notes "$(cat release-notes.md)"
+          args: release --clean --release-notes release-notes.md
         env:
           # GitHub sets the GITHUB_TOKEN secret automatically.
           GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}


### PR DESCRIPTION
Github action workflow step using `goreleaser` to release binaries for **Terraform registry** had incorrectly configured `--release-notes` argument. Instead of passing in _Markdown_ file, the contents of this file where configured to be passed in.