### PR TITLE
cicd(fix|docs): coverage goreport and master pipeline badges

### DIFF
--- a/.github/workflows/master.yml
+++ b/.github/workflows/master.yml
@@ -17,7 +17,7 @@ permissions:
 jobs:
   tests:
     if: github.event_name == 'push' && !startsWith(github.ref, 'refs/tags/')
-    uses: ./.github/workflows/tests.yml
+    uses: ./.github/workflows/test.yml
   coverage-check:
     if: github.event_name == 'push' && !startsWith(github.ref, 'refs/tags/')
     runs-on: ubuntu-latest


### PR DESCRIPTION
Fixes: https://github.com/kiwicom/terraform-provider-montecarlo/pull/20  
Error:
```
error parsing called workflow
".github/workflows/master.yml"
-> "./.github/workflows/tests.yml"
: failed to fetch workflow: workflow was not found.
```