### PR TITLE
cicd(fix|docs): master check coverage depends on test

### DIFF
--- a/.github/workflows/master.yml
+++ b/.github/workflows/master.yml
@@ -20,6 +20,7 @@ jobs:
     uses: ./.github/workflows/test.yml
   coverage-check:
     if: github.event_name == 'push' && !startsWith(github.ref, 'refs/tags/')
+    needs: tests
     runs-on: ubuntu-latest
     steps:
       - name: check test coverage


### PR DESCRIPTION
Fixes: https://github.com/kiwicom/terraform-provider-montecarlo/pull/20  
Error:
```
error parsing called workflow
".github/workflows/master.yml"
-> "./.github/workflows/tests.yml"
: failed to fetch workflow: workflow was not found.
```