### PR TITLE
cicd(fix|docs): master check coverage file location

### DIFF
--- a/.github/workflows/master.yml
+++ b/.github/workflows/master.yml
@@ -31,7 +31,7 @@ jobs:
         id: coverage ## this step must have id
         uses: vladopajic/go-test-coverage@v2
         with:
-          profile: ./coverage.out
+          profile: coverage.out
           local-prefix: github.com/kiwicom/terraform-provider-montecarlo
           threshold-file: 0
           threshold-package: 0


### PR DESCRIPTION
Fixes: https://github.com/kiwicom/terraform-provider-montecarlo/pull/20  
Error:
```
error parsing called workflow
".github/workflows/master.yml"
-> "./.github/workflows/tests.yml"
: failed to fetch workflow: workflow was not found.
```