### PR TITLE
cicd(fix|docs): master check coverage file directory

### DIFF
--- a/.github/workflows/master.yml
+++ b/.github/workflows/master.yml
@@ -26,7 +26,6 @@ jobs:
       - uses: actions/download-artifact@v3
         with:
           name: coverage
-          path: ./coverage.out
       - name: check test coverage
         id: coverage ## this step must have id
         uses: vladopajic/go-test-coverage@v2


### PR DESCRIPTION
Fixes: https://github.com/kiwicom/terraform-provider-montecarlo/pull/20  
Error:
```
error parsing called workflow
".github/workflows/master.yml"
-> "./.github/workflows/tests.yml"
: failed to fetch workflow: workflow was not found.
```