### PR TITLE
cicd(fix|docs): master check coverage wrong file format

### DIFF
--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -23,9 +23,8 @@ jobs:
         with:
           terraform_version: '1.5.*'
           terraform_wrapper: false
-      - run: |
-          go test -v ./... -covermode=count -coverprofile=coverage.out
-          go tool cover -func=coverage.out -o=coverage.out
+      - run:
+          go test -v ./... -coverprofile=coverage.out
         env:
           TF_ACC: '1'
       - uses: actions/upload-artifact@v3


### PR DESCRIPTION
Fixes: https://github.com/kiwicom/terraform-provider-montecarlo/pull/20  
Error:
```
error parsing called workflow
".github/workflows/master.yml"
-> "./.github/workflows/tests.yml"
: failed to fetch workflow: workflow was not found.
```