### PR TITLE
doc(repo|changelog): repeating version and full diff

### DIFF
--- a/.chglog/CHANGELOG.tpl.md
+++ b/.chglog/CHANGELOG.tpl.md
@@ -1,6 +1,6 @@
 {{ range .Versions }}
 <a name="{{ .Tag.Name }}"></a>
-## {{ if .Tag.Previous }}[{{ .Tag.Name }}]({{ $.Info.RepositoryURL }}/compare/{{ .Tag.Previous.Name }}...{{ .Tag.Name }}){{ else }}{{ .Tag.Name }}{{ end }}
+- Full diff - {{ if .Tag.Previous }}**[{{ .Tag.Previous.Name }}...{{ .Tag.Name }}]({{ $.Info.RepositoryURL }}/compare/{{ .Tag.Previous.Name }}...{{ .Tag.Name }})**{{ else }}{{ .Tag.Name }}{{ end }}  
 
 > {{ datetime "2006-01-02" .Tag.Date }}
 

--- a/.chglog/config.yml
+++ b/.chglog/config.yml
@@ -10,13 +10,13 @@ options:
          - feat
          - fix
          - perf
-    #     - refactor
+         - docs
   commit_groups:
      title_maps:
-       feat: Features
-       fix: Bug Fixes
-       perf: Performance Improvements
-    #   refactor: Code Refactoring
+       feat: ":sparkles: Features"
+       fix: ":bug: Bug Fixes"
+       perf: ":zap: Performance Improvements"
+       docs: ":books: Documentation (unchanged functionality)"
   header:
     pattern: "^(\\w*)(?:\\(([\\w\\$\\.\\-\\*\\s\\:\\|\\-]*)\\))?\\:\\s(.*)$"
     pattern_maps:


### PR DESCRIPTION
Changelogs uploaded to the **Github** releases up until to this point were duplicating version of the release - e.g.
https://github.com/kiwicom/terraform-provider-montecarlo/releases/tag/v0.1.0  

Changes presented in this MR change behaviour of the changelog generation such that it is more streamlined with Github releases. Additionally new commit types has been added to be included in resulting changelog.