### PR TITLE
fix(warehouse|bigquery): read operation - inconsistent data collector

### DIFF
--- a/monte_carlo/client/monte_carlo_client.go
+++ b/monte_carlo/client/monte_carlo_client.go
@@ -98,6 +98,9 @@ type GetWarehouse struct {
 			Uuid string `json:"uuid"`
 			Type string `json:"type"`
 		} `json:"connections"`
+		DataCollector struct {
+			Uuid string `json:"uuid"`
+		} `json:"dataCollector"`
 	} `json:"getWarehouse"`
 }
 

--- a/monte_carlo/resources/bigquery_warehouse.go
+++ b/monte_carlo/resources/bigquery_warehouse.go
@@ -278,15 +278,14 @@ func (r *BigQueryWarehouseResource) Delete(ctx context.Context, req resource.Del
 }
 
 func (r *BigQueryWarehouseResource) ImportState(ctx context.Context, req resource.ImportStateRequest, resp *resource.ImportStateResponse) {
-	if idsImported := strings.Split(req.ID, ","); len(idsImported) == 2 && idsImported[0] != "" && idsImported[1] != "" {
+	idsImported := strings.Split(req.ID, ",")
+	if len(idsImported) == 3 && idsImported[0] != "" && idsImported[1] != "" && idsImported[2] != "" {
 		resp.Diagnostics.Append(resp.State.SetAttribute(ctx, path.Root("uuid"), idsImported[0])...)
 		resp.Diagnostics.Append(resp.State.SetAttribute(ctx, path.Root("connection_uuid"), idsImported[1])...)
-		// since the Read operation is not capable of reading service_account_key - force its update right after import
-		resp.Diagnostics.Append(resp.State.SetAttribute(ctx, path.Root("service_account_key"), (*string)(nil))...)
+		resp.Diagnostics.Append(resp.State.SetAttribute(ctx, path.Root("data_collector_uuid"), idsImported[2])...)
 	} else {
-		resp.Diagnostics.AddError(
-			"Unexpected Import Identifier",
-			fmt.Sprintf("Expected import identifier with format: <warehouse_uuid>,<connection_uuid>. Got: %q", req.ID),
+		resp.Diagnostics.AddError("Unexpected Import Identifier", fmt.Sprintf(
+			"Expected import identifier with format: <warehouse_uuid>,<connection_uuid>,<data_collector_uuid>. Got: %q", req.ID),
 		)
 	}
 }

--- a/monte_carlo/resources/bigquery_warehouse.go
+++ b/monte_carlo/resources/bigquery_warehouse.go
@@ -167,6 +167,20 @@ func (r *BigQueryWarehouseResource) Read(ctx context.Context, req resource.ReadR
 		return
 	}
 
+	readDataCollectorUuid := getResult.GetWarehouse.DataCollector.Uuid
+	confDataCollectorUuid := data.DataCollectorUuid.ValueString()
+	if readDataCollectorUuid != confDataCollectorUuid {
+		resp.Diagnostics.AddError(
+			fmt.Sprintf("Obtained BigQuery warehouse with [uuid: %s] but its Data Collector UUID does not match with "+
+				"configured value [obtained: %s, configured: %s]. BigQuery warehouse might have been moved to other "+
+				"Data Collector externally", data.Uuid.ValueString(), readDataCollectorUuid, confDataCollectorUuid),
+			"Since its not possible for this provider to update Data Collector of BigQuery warehouse, this resource "+
+				"cannot continue to function properly. It is recommended to change Data Collector UUID for this "+
+				"resource directly in the Terraform configuration",
+		)
+		return
+	}
+
 	readConnectionUuid := types.StringNull()
 	readServiceAccountKey := types.StringNull()
 	for _, connection := range getResult.GetWarehouse.Connections {

--- a/monte_carlo/resources/bigquery_warehouse_test.go
+++ b/monte_carlo/resources/bigquery_warehouse_test.go
@@ -40,9 +40,9 @@ func TestAccBigQueryWarehouseResource(t *testing.T) {
 				ResourceName:                         "montecarlo_bigquery_warehouse.test",
 				ImportState:                          true,
 				ImportStateVerify:                    true,
-				ImportStateId:                        "8bfc4,8cd5a",
+				ImportStateId:                        "8bfc4,8cd5a,dataCollector1",
 				ImportStateVerifyIdentifierAttribute: "uuid",
-				ImportStateVerifyIgnore:              []string{"data_collector_uuid", "deletion_protection", "service_account_key"},
+				ImportStateVerifyIgnore:              []string{"deletion_protection", "service_account_key"},
 			},
 			// Update and Read testing
 			{
@@ -98,7 +98,7 @@ func initMonteCarloClient() client.MonteCarloClient {
 	// Read operations
 	readQuery := "query getWarehouse($uuid: UUID) { getWarehouse(uuid: $uuid) { name,connections{uuid,type} } }"
 	readVariables1 := map[string]interface{}{"uuid": client.UUID("8bfc4")}
-	readResponse1 := []byte(`{"getWarehouse":{"name":"name1","connections":[{"uuid":"8cd5a"}]}}`)
+	readResponse1 := []byte(`{"getWarehouse":{"name":"name1","connections":[{"uuid":"8cd5a"}],"dataCollector":{"uuid":"dataCollector1"}}}`)
 	mcClient.On("ExecRaw", mock.Anything, readQuery, readVariables1).Return(readResponse1, nil)
 
 	// Delete operations
@@ -120,7 +120,7 @@ func initMonteCarloClient() client.MonteCarloClient {
 		arg.UpdateCredentials.Success = true
 		// after update, read operation must return new results
 		mcClient.On("ExecRaw", mock.Anything, readQuery, readVariables1).Unset()
-		readResponse := []byte(`{"getWarehouse":{"name":"name2","connections":[{"uuid":"8cd5a"}]}}`)
+		readResponse := []byte(`{"getWarehouse":{"name":"name2","connections":[{"uuid":"8cd5a"}],"dataCollector":{"uuid":"dataCollector1"}}}`)
 		mcClient.On("ExecRaw", mock.Anything, readQuery, readVariables1).Return(readResponse, nil)
 	})
 	return &mcClient


### PR DESCRIPTION
While it is not possible now, it might be possible in the future that [Data Collector](https://docs.getmontecarlo.com/docs/data-collector) for already existing _BigQuery warehouse_ resource will change externally in the **Monte Carlo** (for example if **Monte Carlo** releases such functionality).  

To prevent issue possibly occurring from such action read operation of **[montecarlo_bigquery_warehouse](https://github.com/kiwicom/terraform-provider-montecarlo/blob/master/monte_carlo/resources/bigquery_warehouse.go)** was fixed to also check whether the **Data Collector** UUID obtained from the API response for read operations is the same as the one provided in the **Terraform configuration** associated with that resource.

If there is inconsistency found in the **Data Collector** UUID, read operation will fail with an error preventing any other issues which might happen during resource `updates`.

If such error would occurs, users will be asked by the error in the **Terraform** output to change configuration of that resource so it matches the current **Data Collector** UUID where the warehouse is deployed. This will force the resource to be updated and if the supplied **Data Collector** UUID is correct the update operation will be successful as well as any other subsequent read operations.

Example of the error users will obtain:
```
Error: Obtained BigQuery warehouse with [uuid: 8bfc4] but its Data Collector UUID does not match with configured value [obtained: eee72529, configured: 5502b1a4]. BigQuery warehouse might have been moved to other Data Collector externally
        
          with montecarlo_bigquery_warehouse.test,
          on terraform_plugin_test.tf line 9, in resource "montecarlo_bigquery_warehouse" "test":
           9: resource "montecarlo_bigquery_warehouse" "test" {
        
Since its not possible for this provider to update Data Collector of BigQuery 
warehouse, this resource cannot continue to function properly. It is 
recommended to change Data Collector UUID for this resource directly in the 
Terraform configuration
```