### PR TITLE
chore(ci|cd): prepare for v0.1.1 release

### DIFF
--- a/.chglog/CHANGELOG.tpl.md
+++ b/.chglog/CHANGELOG.tpl.md
@@ -1,8 +1,10 @@
 {{ range .Versions }}
 <a name="{{ .Tag.Name }}"></a>
-- Full diff - {{ if .Tag.Previous }}**[{{ .Tag.Previous.Name }}...{{ .Tag.Name }}]({{ $.Info.RepositoryURL }}/compare/{{ .Tag.Previous.Name }}...{{ .Tag.Name }})**{{ else }}{{ .Tag.Name }}{{ end }}  
+## {{ .Tag.Name }}
 
 > {{ datetime "2006-01-02" .Tag.Date }}
+
+- Full diff - {{ if .Tag.Previous }}**[{{ .Tag.Previous.Name }}...{{ .Tag.Name }}]({{ $.Info.RepositoryURL }}/compare/{{ .Tag.Previous.Name }}...{{ .Tag.Name }})**{{ else }}{{ .Tag.Name }}{{ end }}  
 
 {{ range .CommitGroups -}}
 ### {{ .Title }}

--- a/.github/workflows/master.yml
+++ b/.github/workflows/master.yml
@@ -66,6 +66,7 @@ jobs:
         run: |
           export CURR_TAG=$(git describe --tags --abbrev=0)
           sed -n '/<a name="'$CURR_TAG'"><\/a>/,/<a name="v/p' CHANGELOG.md | sed '$d' > release-notes.md
+          sed -i '/^## '$CURR_TAG'$/d' release-notes.md
           grep '<a name="'$CURR_TAG'"></a>' release-notes.md
       - name: Import GPG key
         uses: crazy-max/ghaction-import-gpg@v6

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,4 +1,15 @@
 
+<a name="v0.1.1"></a>
+## v0.1.1
+
+> 2023-10-04
+
+- Full diff - **[v0.1.0...v0.1.1](https://github.com/kiwicom/terraform-provider-montecarlo/compare/v0.1.0...v0.1.1)**  
+
+### :bug: Bug Fixes
+
+* **warehouse|bigquery:** read operation - inconsistent data collector ([#29](https://github.com/kiwicom/terraform-provider-montecarlo/issues/29))
+
 
 <a name="v0.1.0"></a>
 ## [v0.1.0](https://github.com/kiwicom/terraform-provider-montecarlo/compare/v0.0.1...v0.1.0)


### PR DESCRIPTION

<a name="v0.1.1"></a>
## v0.1.1

> 2023-10-04

- Full diff - **[v0.1.0...v0.1.1](https://github.com/kiwicom/terraform-provider-montecarlo/compare/v0.1.0...v0.1.1)**  

### :bug: Bug Fixes

* **warehouse|bigquery:** read operation - inconsistent data collector ([#29](https://github.com/kiwicom/terraform-provider-montecarlo/issues/29))
