### PR TITLE
fix(warehouse|bigquery): read operation - response missing dataCollector

### DIFF
--- a/monte_carlo/resources/bigquery_warehouse.go
+++ b/monte_carlo/resources/bigquery_warehouse.go
@@ -147,7 +147,7 @@ func (r *BigQueryWarehouseResource) Read(ctx context.Context, req resource.ReadR
 
 	getResult := client.GetWarehouse{}
 	variables := map[string]interface{}{"uuid": client.UUID(data.Uuid.ValueString())}
-	query := "query getWarehouse($uuid: UUID) { getWarehouse(uuid: $uuid) { name,connections{uuid,type} } }"
+	query := "query getWarehouse($uuid: UUID) { getWarehouse(uuid: $uuid) { name,connections{uuid,type},dataCollector{uuid} } }"
 
 	if bytes, err := r.client.ExecRaw(ctx, query, variables); err != nil && (bytes == nil || len(bytes) == 0) {
 		toPrint := fmt.Sprintf("MC client 'GetWarehouse' query result - %s", err.Error())

--- a/monte_carlo/resources/bigquery_warehouse_test.go
+++ b/monte_carlo/resources/bigquery_warehouse_test.go
@@ -96,7 +96,7 @@ func initMonteCarloClient() client.MonteCarloClient {
 	})
 
 	// Read operations
-	readQuery := "query getWarehouse($uuid: UUID) { getWarehouse(uuid: $uuid) { name,connections{uuid,type} } }"
+	readQuery := "query getWarehouse($uuid: UUID) { getWarehouse(uuid: $uuid) { name,connections{uuid,type},dataCollector{uuid} } }"
 	readVariables1 := map[string]interface{}{"uuid": client.UUID("8bfc4")}
 	readResponse1 := []byte(`{"getWarehouse":{"name":"name1","connections":[{"uuid":"8cd5a"}],"dataCollector":{"uuid":"dataCollector1"}}}`)
 	mcClient.On("ExecRaw", mock.Anything, readQuery, readVariables1).Return(readResponse1, nil)


### PR DESCRIPTION
**Provider version**: [v0.1.1](https://github.com/kiwicom/terraform-provider-montecarlo/releases/tag/v0.1.1)  

Functionality of read operation was affected by [introducing](https://github.com/kiwicom/terraform-provider-montecarlo/pull/29) Data Collector UUID inconsistency detection.
While logical flow of checking for such inconsistency works as expected, client was not requesting the necessary data from the **Monte Carlo** API leading to unwanted behaviour during regular usage of this provider.