### PR TITLE
docs(examples): fixed provider instalation syntax and usage

### DIFF
--- a/docs/index.md
+++ b/docs/index.md
@@ -15,14 +15,14 @@ This open-source _Terraform_ provider enables users to seamlessly and quickly in
 ```terraform
 terraform {
   required_providers {
-    monte_carlo = {
+    montecarlo = {
       source  = "kiwicom/montecarlo"
       version = "~> 0.0.1"
     }
   }
 }
 
-provider "monte_carlo" {
+provider "montecarlo" {
   account_service_key = {
     id    = "montecarlo"
     token = "montecarlo"

--- a/examples/provider/provider.tf
+++ b/examples/provider/provider.tf
@@ -1,13 +1,13 @@
 terraform {
   required_providers {
-    monte_carlo = {
+    montecarlo = {
       source  = "kiwicom/montecarlo"
       version = "~> 0.0.1"
     }
   }
 }
 
-provider "monte_carlo" {
+provider "montecarlo" {
   account_service_key = {
     id    = "montecarlo"
     token = "montecarlo"


### PR DESCRIPTION
Using **examples** from the documentation of this provider to initialise provider caused syntax errors.  
This issue was also preventing automatic discovery of provider for its resources to work properly.  Documentation has been updated to include examples preventing those issues.

```terraform
terraform {
  required_providers {
    monte_carlo = {
      source  = "kiwicom/montecarlo"
      version = "~> 0.0.1"
    }
  }
}

provider "monte_carlo" {
  account_service_key = {
    id    = "montecarlo"
    token = "montecarlo"
  }
}
```
Error:
```
│ Error: Failed to query available provider packages
│ 
│ Could not retrieve the list of available versions for provider hashicorp/montecarlo: provider registry registry.terraform.io does not have a provider named
│ registry.terraform.io/hashicorp/montecarlo
│ 
│ Did you intend to use kiwicom/montecarlo? If so, you must specify that source address in each module which requires that provider. To see which modules are currently depending
│ on hashicorp/montecarlo, run the following command:
│     terraform providers
```