### PR TITLE
feat(resource|domain): import state via domain uuid

### DIFF
--- a/monte_carlo/resources/domain.go
+++ b/monte_carlo/resources/domain.go
@@ -9,6 +9,7 @@ import (
 	"github.com/kiwicom/terraform-provider-montecarlo/monte_carlo/common"
 
 	"github.com/hashicorp/terraform-plugin-framework/attr"
+	"github.com/hashicorp/terraform-plugin-framework/path"
 	"github.com/hashicorp/terraform-plugin-framework/resource"
 	"github.com/hashicorp/terraform-plugin-framework/resource/schema"
 	"github.com/hashicorp/terraform-plugin-framework/resource/schema/listdefault"
@@ -250,6 +251,7 @@ func (r *DomainResource) Delete(ctx context.Context, req resource.DeleteRequest,
 }
 
 func (r *DomainResource) ImportState(ctx context.Context, req resource.ImportStateRequest, resp *resource.ImportStateResponse) {
+	resource.ImportStatePassthroughID(ctx, path.Root("uuid"), req, resp)
 }
 
 func normalize(in []basetypes.StringValue) []string {

--- a/monte_carlo/resources/domain_test.go
+++ b/monte_carlo/resources/domain_test.go
@@ -38,6 +38,13 @@ func TestAccDomainResource(t *testing.T) {
 					resource.TestCheckResourceAttr("montecarlo_domain.test", "tags.1.value", ""),
 				),
 			},
+			{ // ImportState testing
+				ResourceName:                         "montecarlo_domain.test",
+				ImportState:                          true,
+				ImportStateVerify:                    true,
+				ImportStateId:                        "8bfc4",
+				ImportStateVerifyIdentifierAttribute: "uuid",
+			},
 		}},
 	)
 }


### PR DESCRIPTION
**Terraform** resources might be configured to import existing state of their "real-world" counterpart.  
For this functionality to work it is necessary that **Terraform** resource implements function `ImportState`.  

This function is called during the `terraform import` command and uses single argument to attach **Terraform** resource to an existing external state. If multiple arguments are required for this action then proper workarounds must be included.  

You can find more in the **Import State** [documentation](https://developer.hashicorp.com/terraform/plugin/framework/resources/import) from **Terraform**.

**Acceptance testing** for `montecarlo_domain` resource.
| _operation_  |  _tags_ |  _assignments_ |
|:---|:---:|:---:|
| Create  | :white_check_mark:  |   |
| Read  | :white_check_mark:  |   |
| Update  |   |   |
| Delete  | :white_check_mark:  |   |
| Import  | :white_check_mark:  |   |