### PR TITLE
feat(resource|postgres_warehouse): kick-off beta version implementation

### DIFF
--- a/monte_carlo/client/monte_carlo_client.go
+++ b/monte_carlo/client/monte_carlo_client.go
@@ -59,22 +59,22 @@ func (transport monteCarloTransport) RoundTrip(req *http.Request) (*http.Respons
 type UUID string
 type JSONString string
 
-type Diagnostic struct {
+type BqTestDiagnostic struct {
 	Cause           string
 	FriendlyMessage string
 	Resolution      string
 }
 
-type Warnings []Diagnostic
-type Errors []Diagnostic
+type BqTestWarnings []BqTestDiagnostic
+type BqTestErrors []BqTestDiagnostic
 
 type TestBqCredentialsV2 struct {
 	TestBqCredentialsV2 struct {
 		Key              string
 		ValidationResult struct {
 			Success  bool
-			Warnings Warnings
-			Errors   Errors
+			Warnings BqTestWarnings
+			Errors   BqTestErrors
 		}
 	} `graphql:"testBqCredentialsV2(validationName: $validationName, connectionDetails: $connectionDetails)"`
 }
@@ -160,4 +160,18 @@ type DeleteDomain struct {
 	DeleteDomain struct {
 		Deleted int
 	} `graphql:"deleteDomain(uuid: $uuid)"`
+}
+
+type DatabaseTestDiagnostic struct {
+	Message string
+	Type    string
+}
+
+type TestDatabaseCredentials struct {
+	TestDatabaseCredentials struct {
+		Key         string
+		Success     bool
+		Warnings    []DatabaseTestDiagnostic
+		Validations []DatabaseTestDiagnostic
+	} `graphql:"testDatabaseCredentials(connectionType: $connectionType, dbName: $dbName, dbType: $dbType, host: $host, port: $port, user: $user, password: $password)"`
 }

--- a/monte_carlo/provider/provider.go
+++ b/monte_carlo/provider/provider.go
@@ -101,6 +101,7 @@ func (p *Provider) Configure(ctx context.Context, req provider.ConfigureRequest,
 func (p *Provider) Resources(ctx context.Context) []func() resource.Resource {
 	return []func() resource.Resource{
 		resources.NewBigQueryWarehouseResource,
+		resources.NewPostgresWarehouseResource,
 		resources.NewDomainResource,
 	}
 }

--- a/monte_carlo/resources/bigquery_warehouse_test.go
+++ b/monte_carlo/resources/bigquery_warehouse_test.go
@@ -85,8 +85,8 @@ func initBigQueryWarehouseMonteCarloClient() client.MonteCarloClient {
 		arg := args.Get(1).(*client.TestBqCredentialsV2)
 		arg.TestBqCredentialsV2.Key = "testKey"
 		arg.TestBqCredentialsV2.ValidationResult.Success = true
-		arg.TestBqCredentialsV2.ValidationResult.Errors = client.Errors{}
-		arg.TestBqCredentialsV2.ValidationResult.Warnings = client.Warnings{}
+		arg.TestBqCredentialsV2.ValidationResult.Errors = client.BqTestErrors{}
+		arg.TestBqCredentialsV2.ValidationResult.Warnings = client.BqTestWarnings{}
 	})
 	mcClient.On("Mutate", mock.Anything, mock.AnythingOfType("*client.AddConnection"), mock.Anything).Return(nil).Run(func(args mock.Arguments) {
 		arg := args.Get(1).(*client.AddConnection)


### PR DESCRIPTION
**Monte Carlo** `postgres_warehouse` snapshot.
Documentation on postgres integration can be found here: **[https://docs.getmontecarlo.com/docs/postgres](https://docs.getmontecarlo.com/docs/postgres)**

This feature request implements initial functionality for `montecarlo_postgres_warehouse` resource which can be used to control **Monte Carlo** postgres warehouses from _Terraform_. So far all of the functionality was not yet tested:
- Create
- Read
- Update
- Delete
- Import