### PR TITLE
docs(gen): removed attributes for docs generation

### DIFF
--- a/monte_carlo/data_sources/warehouse.go
+++ b/monte_carlo/data_sources/warehouse.go
@@ -47,39 +47,31 @@ func (d *WarehouseDataSource) Metadata(ctx context.Context, req datasource.Metad
 
 func (d *WarehouseDataSource) Schema(ctx context.Context, req datasource.SchemaRequest, resp *datasource.SchemaResponse) {
 	resp.Schema = schema.Schema{
-		MarkdownDescription: "",
 		Attributes: map[string]schema.Attribute{
 			"uuid": schema.StringAttribute{
-				Required:            true,
-				MarkdownDescription: "",
+				Required: true,
 			},
 			"projects": schema.MapNestedAttribute{
-				Computed:            true,
-				Optional:            false,
-				MarkdownDescription: "",
+				Computed: true,
+				Optional: false,
 				NestedObject: schema.NestedAttributeObject{
 					Attributes: map[string]schema.Attribute{
 						"mcon": schema.StringAttribute{
-							Required:            true,
-							MarkdownDescription: "",
+							Required: true,
 						},
 						"datasets": schema.MapNestedAttribute{
-							MarkdownDescription: "",
-							Required:            true,
+							Required: true,
 							NestedObject: schema.NestedAttributeObject{
 								Attributes: map[string]schema.Attribute{
 									"mcon": schema.StringAttribute{
-										Required:            true,
-										MarkdownDescription: "",
+										Required: true,
 									},
 									"tables": schema.MapNestedAttribute{
-										MarkdownDescription: "",
-										Required:            true,
+										Required: true,
 										NestedObject: schema.NestedAttributeObject{
 											Attributes: map[string]schema.Attribute{
 												"mcon": schema.StringAttribute{
-													Required:            true,
-													MarkdownDescription: "",
+													Required: true,
 												},
 											},
 										},

--- a/monte_carlo/provider/provider.go
+++ b/monte_carlo/provider/provider.go
@@ -46,25 +46,17 @@ func (p *Provider) Metadata(ctx context.Context, req provider.MetadataRequest, r
 
 func (p *Provider) Schema(ctx context.Context, req provider.SchemaRequest, resp *provider.SchemaResponse) {
 	resp.Schema = schema.Schema{
-		MarkdownDescription: "This open-source _Terraform_ provider enables users to seamlessly and quickly integrate the " +
-			"**[Monte Carlo](https://www.montecarlodata.com/)** data reliabillity platform into their infrastructure as a code " +
-			"(IaC) workflows. Provider ensures this functionality by communicating with **Monte Carlo** via its GraphQL API.",
 		Attributes: map[string]schema.Attribute{
 			"account_service_key": schema.SingleNestedAttribute{
-				MarkdownDescription: "Monte Carlo generated **Account Service Key** used to authenticate API calls of " +
-					"this provider. Should not be confused with personal API key. <br><br>For more information: " +
-					"https://docs.getmontecarlo.com/docs/creating-an-api-token#creating-an-api-key <br><br>",
 				Required: true,
 				Attributes: map[string]schema.Attribute{
 					"id": schema.StringAttribute{
-						MarkdownDescription: "Monte Carlo **Account service key** _ID_.",
-						Required:            true,
-						Sensitive:           true,
+						Required:  true,
+						Sensitive: true,
 					},
 					"token": schema.StringAttribute{
-						MarkdownDescription: "Monte Carlo **Account service key** _token_.",
-						Required:            true,
-						Sensitive:           true,
+						Required:  true,
+						Sensitive: true,
 					},
 				},
 			},

--- a/monte_carlo/resources/domain.go
+++ b/monte_carlo/resources/domain.go
@@ -50,44 +50,34 @@ func (r *DomainResource) Metadata(ctx context.Context, req resource.MetadataRequ
 
 func (r *DomainResource) Schema(ctx context.Context, req resource.SchemaRequest, resp *resource.SchemaResponse) {
 	resp.Schema = schema.Schema{
-		// This description is used by the documentation generator and the language server.
-		MarkdownDescription: "**(Beta version !!)** A named resource which lets you define a collection of tables or views by selecting " +
-			"a combination of tables, schemas or databases. Domains can be used to create notifications and authorization groups as " +
-			"a way to adjust the scope without having to redefine a list of tables every time.",
 		Attributes: map[string]schema.Attribute{
 			"uuid": schema.StringAttribute{
-				Computed:            true,
-				Optional:            false,
-				MarkdownDescription: "Unique identifier of domain managed by this resource.",
+				Computed: true,
+				Optional: false,
 				PlanModifiers: []planmodifier.String{
 					stringplanmodifier.UseStateForUnknown(),
 				},
 			},
 			"name": schema.StringAttribute{
-				Required:            true,
-				MarkdownDescription: "The name of the Domain as it will be presented in Monte Carlo.",
+				Required: true,
 			},
 			"description": schema.StringAttribute{
-				Computed:            true,
-				Optional:            true,
-				Default:             stringdefault.StaticString(""),
-				MarkdownDescription: "Description of the domain as it will be presented in Monte Carlo.",
+				Computed: true,
+				Optional: true,
+				Default:  stringdefault.StaticString(""),
 			},
 			"tags": schema.SetNestedAttribute{
-				Computed:            true,
-				Optional:            true,
-				MarkdownDescription: "Filter by tag key/value pairs for tables.",
+				Computed: true,
+				Optional: true,
 				NestedObject: schema.NestedAttributeObject{
 					Attributes: map[string]schema.Attribute{
 						"name": schema.StringAttribute{
-							Required:            true,
-							MarkdownDescription: "Tag name",
+							Required: true,
 						},
 						"value": schema.StringAttribute{
-							Computed:            true,
-							Optional:            true,
-							Default:             stringdefault.StaticString(""),
-							MarkdownDescription: "Tag value",
+							Computed: true,
+							Optional: true,
+							Default:  stringdefault.StaticString(""),
 						},
 					},
 				},
@@ -102,8 +92,6 @@ func (r *DomainResource) Schema(ctx context.Context, req resource.SchemaRequest,
 				Computed:    true,
 				Optional:    true,
 				ElementType: types.StringType,
-				MarkdownDescription: "Objects assigned to domain (in MCONs format: " +
-					"MCON++{account_uuid}++{resource_uuid}++{object_type}++{object_id}).",
 				Default: setdefault.StaticValue(
 					types.SetValueMust(
 						types.StringType,

--- a/monte_carlo/resources/transactional_warehouse.go
+++ b/monte_carlo/resources/transactional_warehouse.go
@@ -59,34 +59,26 @@ func (r *TransactionalWarehouseResource) Metadata(ctx context.Context, req resou
 
 func (r *TransactionalWarehouseResource) Schema(ctx context.Context, req resource.SchemaRequest, resp *resource.SchemaResponse) {
 	resp.Schema = schema.Schema{
-		// This description is used by the documentation generator and the language server.
-		MarkdownDescription: "This resource represents the integration of Monte Carlo with transactional data warehouse. " +
-			"While this resource is not responsible for handling data access and other operations, such as data filtering, " +
-			"it is responsible for managing the connection to transactional db using the provided configuration.",
 		Attributes: map[string]schema.Attribute{
 			"uuid": schema.StringAttribute{
-				Computed:            true,
-				Optional:            false,
-				MarkdownDescription: "Unique identifier of warehouse managed by this resource.",
+				Computed: true,
+				Optional: false,
 				PlanModifiers: []planmodifier.String{
 					stringplanmodifier.UseStateForUnknown(),
 				},
 			},
 			"connection_uuid": schema.StringAttribute{
-				Computed:            true,
-				Optional:            false,
-				MarkdownDescription: "Unique identifier of connection responsible for communication with transactional db.",
+				Computed: true,
+				Optional: false,
 				PlanModifiers: []planmodifier.String{
 					stringplanmodifier.UseStateForUnknown(),
 				},
 			},
 			"name": schema.StringAttribute{
-				Required:            true,
-				MarkdownDescription: "The name of the Postgre warehouse as it will be presented in Monte Carlo.",
+				Required: true,
 			},
 			"db_type": schema.StringAttribute{
-				Required:            true,
-				MarkdownDescription: "ss",
+				Required: true,
 				Validators: []validator.String{
 					stringvalidator.OneOf("POSTGRES", "MYSQL", "SQL-SERVER"),
 				},
@@ -96,44 +88,32 @@ func (r *TransactionalWarehouseResource) Schema(ctx context.Context, req resourc
 			},
 			"collector_uuid": schema.StringAttribute{
 				Required: true,
-				MarkdownDescription: "Unique identifier of data collector this warehouse will be attached to. " +
-					"Its not possible to change data collectors of already created warehouses, therefore if Terraform " +
-					"detects change in this attribute it will plan recreation (which might not be successfull due to deletion " +
-					"protection flag). Since this property is immutable in Monte Carlo warehouses it can only be changed in the configuration",
 				PlanModifiers: []planmodifier.String{
 					stringplanmodifier.RequiresReplaceIfConfigured(),
 				},
 			},
 			"configuration": schema.SingleNestedAttribute{
 				Required: true,
-				MarkdownDescription: "Configuration used by the warehouse connection for connecting " +
-					"to the transactional database. For more information follow Monte Carlo documentation: " +
-					"https://docs.getmontecarlo.com/docs/postgres",
 				Attributes: map[string]schema.Attribute{
 					"host": schema.StringAttribute{
-						Required:            true,
-						MarkdownDescription: "Database host",
+						Required: true,
 					},
 					"port": schema.Int64Attribute{
-						Required:            true,
-						MarkdownDescription: "Database port",
+						Required: true,
 					},
 					"database": schema.StringAttribute{
-						Required:            true,
-						MarkdownDescription: "Database name",
+						Required: true,
 						PlanModifiers: []planmodifier.String{
 							stringplanmodifier.RequiresReplaceIfConfigured(),
 						},
 					},
 					"username": schema.StringAttribute{
-						Required:            true,
-						Sensitive:           true,
-						MarkdownDescription: "Login username",
+						Required:  true,
+						Sensitive: true,
 					},
 					"password": schema.StringAttribute{
-						Required:            true,
-						Sensitive:           true,
-						MarkdownDescription: "Login password",
+						Required:  true,
+						Sensitive: true,
 					},
 				},
 			},
@@ -141,9 +121,6 @@ func (r *TransactionalWarehouseResource) Schema(ctx context.Context, req resourc
 				Optional: true,
 				Computed: true,
 				Default:  booldefault.StaticBool(true),
-				MarkdownDescription: "Whether or not to allow Terraform to destroy the instance. Unless this field is set " +
-					"to false in Terraform state, a terraform destroy or terraform apply that would delete the instance will fail. " +
-					"This setting will prevent the deletion even if the real resource is already deleted.",
 			},
 		},
 	}


### PR DESCRIPTION
**Terraform Registry** documentation is no longer being generated directly from the code. This approach was not perfect since it was obfuscating the code and more advanced **Markdown** techniques could not be utilised.

All of the `MarkdowDescription` attributes were removed from _resources_ and _data sources_.