### PR TITLE
feat(iam): IAM member resource implemented

### DIFF
--- a/monte_carlo/client/monte_carlo_client.go
+++ b/monte_carlo/client/monte_carlo_client.go
@@ -210,6 +210,14 @@ type GetTables struct {
 	} `graphql:"getTables(dwId: $dwId, first: $first, after: $after, isDeleted: $isDeleted, isExcluded: $isExcluded)"`
 }
 
+type User struct {
+	Id        string
+	Email     string
+	FirstName string
+	LastName  string
+	IsSso     bool
+}
+
 type AuthorizationGroup struct {
 	Name               string
 	Label              string
@@ -218,6 +226,7 @@ type AuthorizationGroup struct {
 	Roles              []struct{ Name string }
 	DomainRestrictions []struct{ Uuid string }
 	SsoGroup           *string
+	Users              []User
 }
 
 type CreateOrUpdateAuthorizationGroup struct {
@@ -234,4 +243,17 @@ type DeleteAuthorizationGroup struct {
 	DeleteAuthorizationGroup struct {
 		Deleted int
 	} `graphql:"deleteAuthorizationGroup(name: $name)"`
+}
+
+type GetUsersInAccount struct {
+	GetUsersInAccount struct {
+		Edges    []struct{
+			Node User
+		}
+		PageInfo struct {
+			StartCursor string
+			EndCursor   string
+			HasNextPage bool
+		}
+	} `graphql:"getTables(email: $email, first: $first, after: $after)"`
 }

--- a/monte_carlo/resources/iam_member.go
+++ b/monte_carlo/resources/iam_member.go
@@ -1,0 +1,270 @@
+package resources
+
+import (
+	"context"
+	"fmt"
+	"regexp"
+	"slices"
+	"strings"
+
+	"github.com/kiwicom/terraform-provider-montecarlo/monte_carlo/client"
+	"github.com/kiwicom/terraform-provider-montecarlo/monte_carlo/common"
+
+	"github.com/hashicorp/terraform-plugin-framework-validators/stringvalidator"
+	"github.com/hashicorp/terraform-plugin-framework/resource"
+	"github.com/hashicorp/terraform-plugin-framework/resource/schema"
+	"github.com/hashicorp/terraform-plugin-framework/resource/schema/planmodifier"
+	"github.com/hashicorp/terraform-plugin-framework/resource/schema/stringplanmodifier"
+	"github.com/hashicorp/terraform-plugin-framework/schema/validator"
+	"github.com/hashicorp/terraform-plugin-framework/types"
+)
+
+var groupsRegex = regexp.MustCompile(`^groups/.+$`)
+var memberRegex = regexp.MustCompile(`^user/.+$`)
+
+// Ensure provider defined types fully satisfy framework interfaces.
+var _ resource.Resource = &IamMemberResource{}
+var _ resource.ResourceWithImportState = &IamMemberResource{}
+
+// To simplify provider implementations, a named function can be created with the resource implementation.
+func NewIamMemberResource() resource.Resource {
+	return &IamMemberResource{}
+}
+
+// IamMemberResource defines the resource implementation.
+type IamMemberResource struct {
+	client client.MonteCarloClient
+}
+
+// IamMemberResourceModel describes the resource data model according to its Schema.
+type IamMemberResourceModel struct {
+	Group    types.String `tfsdk:"group"`
+	Member   types.String `tfsdk:"member"`
+	MemberId types.String `tfsdk:"member_id"`
+}
+
+func (r *IamMemberResource) Metadata(ctx context.Context, req resource.MetadataRequest, resp *resource.MetadataResponse) {
+	resp.TypeName = req.ProviderTypeName + "_iam_member"
+}
+
+func (r *IamMemberResource) Schema(ctx context.Context, req resource.SchemaRequest, resp *resource.SchemaResponse) {
+	resp.Schema = schema.Schema{
+		Attributes: map[string]schema.Attribute{
+			"group": schema.StringAttribute{
+				Required: true,
+				PlanModifiers: []planmodifier.String{
+					stringplanmodifier.RequiresReplaceIfConfigured(),
+				},
+				Validators: []validator.String{
+					stringvalidator.RegexMatches(groupsRegex, "Expected format: groups/{group_name}"),
+				},
+			},
+			"member": schema.StringAttribute{
+				Required: true,
+				PlanModifiers: []planmodifier.String{
+					stringplanmodifier.RequiresReplaceIfConfigured(),
+				},
+				Validators: []validator.String{
+					stringvalidator.RegexMatches(memberRegex, "Expected format: user/{user_email}"),
+				},
+			},
+			"member_id": schema.StringAttribute{
+				Computed: true,
+				Optional: false,
+				PlanModifiers: []planmodifier.String{
+					stringplanmodifier.UseStateForUnknown(),
+				},
+			},
+		},
+	}
+}
+
+func (r *IamMemberResource) Configure(ctx context.Context, req resource.ConfigureRequest, resp *resource.ConfigureResponse) {
+	client, diags := common.Configure(req)
+	resp.Diagnostics.Append(diags...)
+	r.client = client
+}
+
+func (r *IamMemberResource) Create(ctx context.Context, req resource.CreateRequest, resp *resource.CreateResponse) {
+	var data IamMemberResourceModel
+	resp.Diagnostics.Append(req.Plan.Get(ctx, &data)...)
+	if resp.Diagnostics.HasError() {
+		return
+	}
+
+	userEmail := strings.Split(data.Member.ValueString(), "user/")[1]
+	getUserResult := client.GetUsersInAccount{}
+	variables := map[string]interface{}{
+		"email": userEmail,
+		"first": 1,
+		"after": (*string)(nil),
+	}
+
+	if err := r.client.Query(ctx, &getUserResult, variables); err != nil {
+		to_print := fmt.Sprintf("MC client 'getTables' query result - %s", err.Error())
+		resp.Diagnostics.AddError(to_print, "")
+		return
+	} else if len(getUserResult.GetUsersInAccount.Edges) == 0 {
+		to_print := fmt.Sprintf("User %s not found", userEmail)
+		resp.Diagnostics.AddError(to_print, "")
+		return
+	}
+
+	groupName := strings.Split(data.Group.ValueString(), "groups/")[1]
+	getGroupResult := client.GetAuthorizationGroups{}
+	variables = map[string]interface{}{}
+	if err := r.client.Query(ctx, &getGroupResult, variables); err != nil {
+		to_print := fmt.Sprintf("MC client 'GetAuthorizationGroups' query result - %s", err.Error())
+		resp.Diagnostics.AddError(to_print, "")
+		return
+	}
+
+	var found *client.AuthorizationGroup
+	if index := slices.IndexFunc(getGroupResult.GetAuthorizationGroups, func(group client.AuthorizationGroup) bool {
+		return !group.IsManaged && group.Name == groupName
+	}); index >= 0 && getGroupResult.GetAuthorizationGroups[index].SsoGroup == nil {
+		found = &getGroupResult.GetAuthorizationGroups[index]
+	} else {
+		to_print := fmt.Sprintf("Group %s not found or is SSO managed", data.Group.ValueString())
+		resp.Diagnostics.AddError(to_print, "")
+		return
+	}
+
+	memberUserIds := make([]string, len(found.Users)+1)
+	memberUserIds[len(found.Users)] = getUserResult.GetUsersInAccount.Edges[0].Node.Id
+	for i, user := range found.Users {
+		memberUserIds[i] = user.Id
+	}
+
+	updateResult := client.CreateOrUpdateAuthorizationGroup{}
+	variables = map[string]interface{}{
+		"name":                 found.Name,
+		"label":                found.Label,
+		"description":          found.Description,
+		"roles":                rolesToNames(found.Roles),
+		"domainRestrictionIds": domainsToUuids(found.DomainRestrictions),
+		"ssoGroup":             found.SsoGroup,
+		"memberUserIds":        memberUserIds,
+	}
+
+	if err := r.client.Mutate(ctx, &updateResult, variables); err != nil {
+		to_print := fmt.Sprintf("MC client 'createOrUpdateAuthorizationGroup' mutation result - %s", err.Error())
+		resp.Diagnostics.AddError(to_print, "")
+	} else {
+		data.MemberId = types.StringValue(getUserResult.GetUsersInAccount.Edges[0].Node.Id)
+		resp.Diagnostics.Append(resp.State.Set(ctx, &data)...)
+	}
+}
+
+func (r *IamMemberResource) Read(ctx context.Context, req resource.ReadRequest, resp *resource.ReadResponse) {
+	var data IamMemberResourceModel
+	resp.Diagnostics.Append(req.State.Get(ctx, &data)...)
+	if resp.Diagnostics.HasError() {
+		return
+	}
+
+	userEmail := strings.Split(data.Member.ValueString(), "user/")[1]
+	getUserResult := client.GetUsersInAccount{}
+	variables := map[string]interface{}{
+		"email": userEmail,
+		"first": 1,
+		"after": (*string)(nil),
+	}
+
+	if err := r.client.Query(ctx, &getUserResult, variables); err != nil {
+		to_print := fmt.Sprintf("MC client 'getTables' query result - %s", err.Error())
+		resp.Diagnostics.AddError(to_print, "")
+		return
+	} else if len(getUserResult.GetUsersInAccount.Edges) == 0 {
+		to_print := fmt.Sprintf("User %s not found", userEmail)
+		resp.Diagnostics.AddError(to_print, "")
+		return
+	}
+
+	groupName := strings.Split(data.Group.ValueString(), "groups/")[1]
+	getGroupResult := client.GetAuthorizationGroups{}
+	variables = map[string]interface{}{}
+	if err := r.client.Query(ctx, &getGroupResult, variables); err != nil {
+		to_print := fmt.Sprintf("MC client 'GetAuthorizationGroups' query result - %s", err.Error())
+		resp.Diagnostics.AddError(to_print, "")
+		return
+	}
+
+	var found *client.AuthorizationGroup
+	for _, group := range getGroupResult.GetAuthorizationGroups {
+		if !group.IsManaged && group.Name == groupName {
+			found = &group
+			break
+		}
+	}
+
+	if found == nil || found.SsoGroup != nil {
+		to_print := fmt.Sprintf("Group %s not found or is SSO managed", data.Group.ValueString())
+		resp.Diagnostics.AddError(to_print, "")
+	} else if !slices.Contains(found.Users, getUserResult.GetUsersInAccount.Edges[0].Node) {
+		to_print := fmt.Sprintf("User %s not found in group %s", userEmail, data.Group.ValueString())
+		resp.Diagnostics.AddWarning(to_print, "")
+		resp.State.RemoveResource(ctx)
+	} else {
+		data.MemberId = types.StringValue(getUserResult.GetUsersInAccount.Edges[0].Node.Id)
+		resp.Diagnostics.Append(resp.State.Set(ctx, &data)...)
+	}
+}
+
+func (r *IamMemberResource) Update(ctx context.Context, req resource.UpdateRequest, resp *resource.UpdateResponse) {
+	// TODO
+}
+
+func (r *IamMemberResource) Delete(ctx context.Context, req resource.DeleteRequest, resp *resource.DeleteResponse) {
+	var data IamMemberResourceModel
+	resp.Diagnostics.Append(req.State.Get(ctx, &data)...)
+	if resp.Diagnostics.HasError() {
+		return
+	}
+
+	groupName := strings.Split(data.Group.ValueString(), "groups/")[1]
+	getGroupResult := client.GetAuthorizationGroups{}
+	variables := map[string]interface{}{}
+	if err := r.client.Query(ctx, &getGroupResult, variables); err != nil {
+		to_print := fmt.Sprintf("MC client 'GetAuthorizationGroups' query result - %s", err.Error())
+		resp.Diagnostics.AddWarning(to_print, "")
+		return
+	}
+
+	var found *client.AuthorizationGroup
+	if index := slices.IndexFunc(getGroupResult.GetAuthorizationGroups, func(group client.AuthorizationGroup) bool {
+		return !group.IsManaged && group.Name == groupName
+	}); index >= 0 && getGroupResult.GetAuthorizationGroups[index].SsoGroup == nil {
+		found = &getGroupResult.GetAuthorizationGroups[index]
+	} else {
+		to_print := fmt.Sprintf("Group %s not found or is SSO managed", data.Group.ValueString())
+		resp.Diagnostics.AddWarning(to_print, "")
+		return
+	}
+
+	memberUserIds := make([]string, len(found.Users))
+	for i, user := range found.Users {
+		memberUserIds[i] = user.Id
+	}
+
+	updateResult := client.CreateOrUpdateAuthorizationGroup{}
+	memberUserIds = slices.DeleteFunc(memberUserIds, func(userId string) bool { return userId == data.MemberId.ValueString() })
+	variables = map[string]interface{}{
+		"name":                 found.Name,
+		"label":                found.Label,
+		"description":          found.Description,
+		"roles":                rolesToNames(found.Roles),
+		"domainRestrictionIds": domainsToUuids(found.DomainRestrictions),
+		"ssoGroup":             found.SsoGroup,
+		"memberUserIds":        memberUserIds,
+	}
+
+	if err := r.client.Mutate(ctx, &updateResult, variables); err != nil {
+		to_print := fmt.Sprintf("MC client 'createOrUpdateAuthorizationGroup' mutation result - %s", err.Error())
+		resp.Diagnostics.AddError(to_print, "")
+	}
+}
+
+func (r *IamMemberResource) ImportState(ctx context.Context, req resource.ImportStateRequest, resp *resource.ImportStateResponse) {
+	// TODO
+}


### PR DESCRIPTION
Merge request https://github.com/kiwicom/terraform-provider-montecarlo/pull/51 implemented resource `montecarlo_iam_group` which is responsible for configuring **Monte Carlo** [authorization groups](https://docs.getmontecarlo.com/docs/authorization). However, this resource is not responsible for **assignment** of members/users to the group it represents.

This Merge Request features resource `montecarlo_iam_member` resource. Its functionality is very similar to the google's **[iam_member](https://registry.terraform.io/providers/hashicorp/google/latest/docs/resources/google_project_iam)** resources. When this resource is used over an existing **Monte Carlo** group with an existing user, it will grant access. This operation is `non-authoritative` - meaning that if multiple of those resources are being used, they will **not override each others grants**.