### PR TITLE
bug(iam): iam_member using groups API for assignment

### DIFF
--- a/monte_carlo/client/monte_carlo_client.go
+++ b/monte_carlo/client/monte_carlo_client.go
@@ -210,7 +210,7 @@ type GetTables struct {
 	} `graphql:"getTables(dwId: $dwId, first: $first, after: $after, isDeleted: $isDeleted, isExcluded: $isExcluded)"`
 }
 
-type User struct {
+type AuthorizationGroupUser struct {
 	CognitoUserId string
 	Email         string
 	FirstName     string
@@ -226,13 +226,13 @@ type AuthorizationGroup struct {
 	Roles              []struct{ Name string }
 	DomainRestrictions []struct{ Uuid string }
 	SsoGroup           *string
-	Users              []User
+	Users              []AuthorizationGroupUser
 }
 
 type CreateOrUpdateAuthorizationGroup struct {
 	CreateOrUpdateAuthorizationGroup struct {
 		AuthorizationGroup AuthorizationGroup
-	} `graphql:"createOrUpdateAuthorizationGroup(name: $name, label: $label, description: $description, roles: $roles, memberUserIds: $memberUserIds, domainRestrictionIds: $domainRestrictionIds, ssoGroup: $ssoGroup)"`
+	} `graphql:"createOrUpdateAuthorizationGroup(name: $name, label: $label, description: $description, roles: $roles, domainRestrictionIds: $domainRestrictionIds, ssoGroup: $ssoGroup)"`
 }
 
 type GetAuthorizationGroups struct {
@@ -243,6 +243,17 @@ type DeleteAuthorizationGroup struct {
 	DeleteAuthorizationGroup struct {
 		Deleted int
 	} `graphql:"deleteAuthorizationGroup(name: $name)"`
+}
+
+type User struct {
+	CognitoUserId string
+	Email         string
+	FirstName     string
+	LastName      string
+	IsSso         bool
+	Auth          struct {
+		Groups []string
+	}
 }
 
 type GetUsersInAccount struct {
@@ -256,4 +267,19 @@ type GetUsersInAccount struct {
 			HasNextPage bool
 		}
 	} `graphql:"getUsersInAccount(email: $email, first: $first, after: $after)"`
+}
+
+type UpdateUserAuthorizationGroupMembership struct {
+	UpdateUserAuthorizationGroupMembership struct {
+		AddedToGroups []struct {
+			Name        string
+			Label       string
+			Description string
+		}
+		RemovedFromGroups []struct {
+			Name        string
+			Label       string
+			Description string
+		}
+	} `graphql:"updateUserAuthorizationGroupMembership(memberUserId: $memberUserId, groupNames: $groupNames)"`
 }

--- a/monte_carlo/resources/iam_group.go
+++ b/monte_carlo/resources/iam_group.go
@@ -122,7 +122,6 @@ func (r *IamGroupResource) Create(ctx context.Context, req resource.CreateReques
 		"roles":                []string{data.Role.ValueString()},
 		"domainRestrictionIds": normalize[client.UUID](data.Domains),
 		"ssoGroup":             data.SsoGroup.ValueStringPointer(),
-		"memberUserIds":        (*[]string)(nil),
 	}
 
 	if err := r.client.Mutate(ctx, &createResult, variables); err == nil {
@@ -187,7 +186,6 @@ func (r *IamGroupResource) Update(ctx context.Context, req resource.UpdateReques
 		"roles":                []string{data.Role.ValueString()},
 		"domainRestrictionIds": normalize[client.UUID](data.Domains),
 		"ssoGroup":             data.SsoGroup.ValueStringPointer(),
-		"memberUserIds":        (*[]string)(nil),
 	}
 
 	if err := r.client.Mutate(ctx, &updateResult, variables); err == nil {


### PR DESCRIPTION
Resource `montecarlo_iam_member` should be using **Monte Carlo** API method _updateUserAuthorizationGroupMembership_.
Previous solution was updating user assignment directly on the group which might have caused issues when run concurrently with any other workflow updating the group.

Resource `montecarlo_iam_member` and its tests were adapted to this new workflow together with small bugfixes found while deleting or reading resource state.