### PR TITLE
chore(cicd): prepare for v0.3.0

### DIFF
--- a/.chglog/config.yml
+++ b/.chglog/config.yml
@@ -11,12 +11,14 @@ options:
          - fix
          - perf
          - docs
+         - test
   commit_groups:
      title_maps:
        feat: ":sparkles: Features"
        fix: ":bug: Bug Fixes"
        perf: ":zap: Performance Improvements"
        docs: ":books: Documentation (unchanged functionality)"
+       test: ":mag: Tests (unchanged functionality)"
   header:
     pattern: "^(\\w*)(?:\\(([\\w\\$\\.\\-\\*\\s\\:\\|\\-]*)\\))?\\:\\s(.*)$"
     pattern_maps:

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,33 @@
 
 
+<a name="v0.3.0"></a>
+## v0.3.0
+
+> 2023-11-01
+
+- Full diff - **[v0.2.1...v0.3.0](https://github.com/kiwicom/terraform-provider-montecarlo/compare/v0.2.1...v0.3.0)**  
+
+### :sparkles: Features
+
+* **iam:** IAM member resource implemented ([#53](https://github.com/kiwicom/terraform-provider-montecarlo/issues/53))
+* **iam:** authorization groups resource implementation ([#50](https://github.com/kiwicom/terraform-provider-montecarlo/issues/50))
+
+### :bug: Bug Fixes
+
+* **iam:** iam_member using groups API for assignment ([#61](https://github.com/kiwicom/terraform-provider-montecarlo/pull/61))
+
+### :books: Documentation (unchanged functionality)
+
+* **gen:** removed attributes for docs generation ([#51](https://github.com/kiwicom/terraform-provider-montecarlo/issues/51))
+* **resources:** iam_member documentation and examples ([#63](https://github.com/kiwicom/terraform-provider-montecarlo/issues/63))
+* **resources:** iam_group documentation and examples ([#60](https://github.com/kiwicom/terraform-provider-montecarlo/issues/60))
+
+### :mag: Tests (unchanged functionality)
+
+* **iam:** member assignment acceptance tests ([#55](https://github.com/kiwicom/terraform-provider-montecarlo/issues/55))
+* **iam:** IAM group resource acceptance tests ([#54](https://github.com/kiwicom/terraform-provider-montecarlo/issues/54))
+
+
 <a name="v0.2.1"></a>
 ## v0.2.1
 

--- a/README.md
+++ b/README.md
@@ -7,7 +7,7 @@
 ![GitHub release](https://img.shields.io/github/v/release/kiwicom/terraform-provider-montecarlo)
 [![Go Report Card](https://goreportcard.com/badge/github.com/kiwicom/terraform-provider-montecarlo)](https://goreportcard.com/report/github.com/kiwicom/terraform-provider-montecarlo)
 ![coverage](https://raw.githubusercontent.com/kiwicom/terraform-provider-montecarlo/badges/.badges/master/coverage.svg)
-![milestone](https://img.shields.io/github/milestones/progress/kiwicom/terraform-provider-montecarlo/1)  
+![milestone](https://img.shields.io/github/milestones/progress/kiwicom/terraform-provider-montecarlo/2)  
 
 [![Terraform](https://img.shields.io/badge/terraform-%235835CC.svg?style=for-the-badge&logo=terraform&logoColor=white)](https://registry.terraform.io/providers/kiwicom/montecarlo/latest)
 
@@ -39,8 +39,8 @@ Provider initialization with <ins>**Account Service Key**</ins>, which is used t
 ```hcl
 provider "monte_carlo" {
   account_service_key = {
-    id    = "montecarlo"
-    token = "montecarlo"
+    id    = var.montecarlo_api_key_id     #(secret)
+    token = var.montecarlo_api_key_token  #(secret)
   }
 }
 ```

--- a/docs/index.md
+++ b/docs/index.md
@@ -29,8 +29,8 @@ terraform {
 
 provider "montecarlo" {
   account_service_key = {
-    id    = var.api_key_id     #(secret)
-    token = var.api_key_token  #(secret)
+    id    = var.montecarlo_api_key_id     #(secret)
+    token = var.montecarlo_api_key_token  #(secret)
   }
 }
 ```

--- a/examples/provider/provider.tf
+++ b/examples/provider/provider.tf
@@ -9,7 +9,7 @@ terraform {
 
 provider "montecarlo" {
   account_service_key = {
-    id    = "montecarlo"  #(secret)
-    token = "montecarlo"  #(secret)
+    id    = var.montecarlo_api_key_id     # (secret)
+    token = var.montecarlo_api_key_token  # (secret)
   }
 }


### PR DESCRIPTION

<a name="v0.3.0"></a>
## v0.3.0

> 2023-11-01
- Full diff - **[v0.2.1...v0.3.0](https://github.com/kiwicom/terraform-provider-montecarlo/compare/v0.2.1...v0.3.0)**  

### :sparkles: Features

* **iam:** IAM member resource implemented ([#53](https://github.com/kiwicom/terraform-provider-montecarlo/issues/53))
* **iam:** authorization groups resource implementation ([#50](https://github.com/kiwicom/terraform-provider-montecarlo/issues/50))

### :bug: Bug Fixes

* **iam:** iam_member using groups API for assignment ([#61](https://github.com/kiwicom/terraform-provider-montecarlo/pull/61))

### :books: Documentation (unchanged functionality)

* **gen:** removed attributes for docs generation ([#51](https://github.com/kiwicom/terraform-provider-montecarlo/issues/51))
* **resources:** iam_member documentation and examples ([#63](https://github.com/kiwicom/terraform-provider-montecarlo/issues/63))
* **resources:** iam_group documentation and examples ([#60](https://github.com/kiwicom/terraform-provider-montecarlo/issues/60))

### :mag: Tests (unchanged functionality)

* **iam:** member assignment acceptance tests ([#55](https://github.com/kiwicom/terraform-provider-montecarlo/issues/55))
* **iam:** IAM group resource acceptance tests ([#54](https://github.com/kiwicom/terraform-provider-montecarlo/issues/54))
