### PR TITLE
fix: fixes multiple bigquery collectors error

### DIFF
--- a/client/monte_carlo_client.go
+++ b/client/monte_carlo_client.go
@@ -76,7 +76,7 @@ type TestBqCredentialsV2 struct {
 			Warnings BqTestWarnings
 			Errors   BqTestErrors
 		}
-	} `graphql:"testBqCredentialsV2(validationName: $validationName, connectionDetails: $connectionDetails)"`
+	} `graphql:"testBqCredentialsV2(validationName: $validationName, connectionDetails: $connectionDetails, dcId: $dcId)"`
 }
 
 type AddConnection struct {

--- a/internal/warehouse/bigquery_warehouse.go
+++ b/internal/warehouse/bigquery_warehouse.go
@@ -321,6 +321,7 @@ func (r *BigQueryWarehouseResource) testCredentials(ctx context.Context, data Bi
 				[]byte(data.Credentials.ServiceAccountKey.ValueString()),
 			),
 		},
+		"dcId": graphql.String(data.CollectorUuid.ValueString()),
 	}
 
 	if err := r.client.Mutate(ctx, &testResult, variables); err != nil {


### PR DESCRIPTION
In the accounts where multiple data collectors exist, the system doesn't know which one to select. To resolve this, data collector (or collector_uuid) used for the queries should be explicitly specified.
<img width="1106" alt="Screenshot 2025-05-15 at 19 30 42" src="https://github.com/user-attachments/assets/fc4890cb-ec8b-4af9-84a2-16eb0fa3c725" />