### PR TITLE
fix: fixes multiple bigquery collectors error

### DIFF
--- a/client/monte_carlo_client.go
+++ b/client/monte_carlo_client.go
@@ -76,7 +76,7 @@ type TestBqCredentialsV2 struct {
 			Warnings BqTestWarnings
 			Errors   BqTestErrors
 		}
-	} `graphql:"testBqCredentialsV2(validationName: $validationName, connectionDetails: $connectionDetails)"`
+	} `graphql:"testBqCredentialsV2(validationName: $validationName, connectionDetails: $connectionDetails, connectionOptions: $connectionOptions)"`
 }
 
 type AddConnection struct {

--- a/internal/warehouse/bigquery_warehouse.go
+++ b/internal/warehouse/bigquery_warehouse.go
@@ -7,6 +7,7 @@ import (
 	"fmt"
 	"strings"
 
+	"github.com/hasura/go-graphql-client"
 	"github.com/kiwicom/terraform-provider-montecarlo/client"
 	"github.com/kiwicom/terraform-provider-montecarlo/internal/common"
 
@@ -313,6 +314,7 @@ func (r *BigQueryWarehouseResource) ImportState(ctx context.Context, req resourc
 func (r *BigQueryWarehouseResource) testCredentials(ctx context.Context, data BigQueryWarehouseResourceModel) (*client.TestBqCredentialsV2, diag.Diagnostics) {
 	var diagsResult diag.Diagnostics
 	type BqConnectionDetails map[string]interface{}
+	type ConnectionTestOptions map[string]interface{}
 	testResult := client.TestBqCredentialsV2{}
 	variables := map[string]interface{}{
 		"validationName": "save_credentials",
@@ -320,6 +322,9 @@ func (r *BigQueryWarehouseResource) testCredentials(ctx context.Context, data Bi
 			"serviceJson": b64.StdEncoding.EncodeToString(
 				[]byte(data.Credentials.ServiceAccountKey.ValueString()),
 			),
+		},
+		"connectionOptions": ConnectionTestOptions{
+			"dcId": graphql.String(data.CollectorUuid.ValueString()),
 		},
 	}
 


### PR DESCRIPTION
In the accounts where multiple data collectors exist, the system doesn't know which one to select. To resolve this, data collector (or collector_uuid) used for the queries should be explicitly specified.
Screenshot 2025-05-15 at 19 30 42